### PR TITLE
feat!: new get-version

### DIFF
--- a/.github/workflows/get-version.yml
+++ b/.github/workflows/get-version.yml
@@ -1,52 +1,115 @@
-name: Get version
+name: Get Version
+# description: Determine the version of the project based on the latest commit and generate a changelog using the Rust Convco cli tool.
 
 on:
   workflow_call:
     inputs:
-      release-branches:
+      convco-version:
         type: string
-        description: The branches on which releases should happen, comma separated name of branches
+        description: 'Version of Convco to use (default: latest)'
         required: false
-        default: 'main'
+        default: 'latest'
+      path:
+        type: string
+        description: 'Only commits that update those <paths> will be taken into account.'
+        required: false
+      release-branch:
+        type: string
+        description: 'Name of the release branch'
+        required: false
+        default: main
       prerelease-branches:
         type: string
-        description: The branches on which prereleases should happen, comma separated name of branches
+        description: 'Prerelease branch names'
         required: false
-        default: 'rc,beta,alpha'
+        default: beta,alpha,rc
+      changelog-include-hidden-section:
+        type: boolean
+        description: 'Include hidden sections in the changelog'
+        required: false
+        default: false
     outputs:
       version:
-        description: The version that was released
-        value: ${{ jobs.get-version.outputs.version }}
-      is-prerelease:
-        description: The version that was released
-        value: ${{ jobs.get-version.outputs.is-prerelease }}
-      changelogs:
-        description: The version that was released
-        value: ${{ jobs.get-version.outputs.changelogs }}
-      will-release:
-        description: The version will be released
-        value: ${{ jobs.get-version.outputs.will-release }}
-
-permissions:
-  contents: write
+        description: 'The calculated version'
+        value: ${{ jobs.get_version.outputs.version }}
+      changelog:
+        description: 'The changes between calculated version and previous version'
+        value: ${{ jobs.get_version.outputs.changelog }}
 
 jobs:
-  get-version:
+  get_version:
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.get-version.outputs.version }}
-      is-prerelease: ${{ steps.get-version.outputs.is-prerelease }}
-      changelogs: ${{ steps.get-version.outputs.changelogs }}
-      will-release: ${{ steps.get-version.outputs.will-release }}
+      version: ${{ steps.get_version.outputs.version }}
+      changelog: ${{ steps.get_version.outputs.changelog }}
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-
-      - id: get-version
-        name: Release
-        uses: lenra-io/github-actions/jobs/release@main
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
         with:
-          dry-run: true
-          release-branches: ${{ inputs.release-branches }}
-          prerelease-branches: ${{ inputs.prerelease-branches }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          toolchain: stable
+          profile: minimal
+      - name: Restore convco from cache
+        id: convco-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/
+            ~/.cargo/git/
+            ~/.cargo/bin/
+            /var/lib/apt/lists
+          key: ${{ runner.os }}-convco-${{ inputs.convco-version }}
+          restore-keys: ${{ runner.os }}-convco-
+      - name: Install cmake
+        run: |
+          if ! command -v cmake &> /dev/null; then
+            sudo apt-get update && sudo apt-get install -y cmake
+          fi
+      - name: Setup convco
+        run: |
+          echo "${{steps.convco-cache.outputs.cache-hit}}"
+      - name: Setup convco
+        if: steps.convco-cache.outputs.cache-hit != 'true'
+        run: |
+          args=""
+          if [ "${{ inputs.convco-version }}" != "latest" ]; then
+            args="--version ${{ inputs.convco-version }}"
+          fi
+          cargo install convco $args --force
+      - name: Determine version using convco CLI
+        id: get_version
+        run: |
+          if [[ -n "${{ inputs.path }}" ]]; then
+            echo "Using path: ${{ inputs.path }}"
+            path_args="--path ${{ inputs.path }}"
+          fi
+          IFS="," read -ra prerelease_branches <<< "${{ inputs.prerelease-branches }}"
+          IFS="," read -ra release_branches <<< "${{ inputs.prerelease-branches }}"
+          current_branch=${{ github.ref_name }}
+          must_release=false
+          if [[ "$IFS${prerelease_branches[*]}$IFS" =~ "$IFS${current_branch}$IFS" ]] ; then
+            must_release=true
+            prerelease_args="--prerelease"
+            channel=${current_branch}
+          fi
+          if [[ "$IFS${prerelease_branches[*]}$IFS" =~ "$IFS${current_branch}$IFS" ]]; then
+            must_release=true
+          fi
+          if ${must_release} ; then
+            if ${{ inputs.changelog-include-hidden-section }} ; then
+              hidden_args="--include-hidden-section"
+            fi
+            VERSION=$(~/.cargo/bin/convco version -b $prerelease_args)
+            CHANGELOG=$(~/.cargo/bin/convco changelog $hidden_args -u $VERSION)
+            echo "Determined version: ${VERSION}"
+            echo "version=${VERSION}" >> $GITHUB_OUTPUT
+            if [ -n "${channel}" ]; then
+              echo "channel=${channel}" >> $GITHUB_OUTPUT
+            fi
+            echo "changelog<<EOF" >> $GITHUB_OUTPUT
+            echo "${CHANGELOG}" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          else
+            echo "Will not release: Event not hit a release_branches or prerelease_branches"
+          fi


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📜 Use Conventional Commit for your PR name (see https://www.conventionalcommits.org/en/v1.0.0/).
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->



## About this PR
<!-- 
Link the related issue if any.
-->

<!-- 
  - What is the bug/feature you make ? (If describe in the issue, don't repeat yourself, tell us)
  - Any other changes not in the issue ? Why did you add them ?
  - Add some scope to the changes if relevant
  - Try to give as much context as possible without any technical stuff here.

  For example : 
  We need some CGU in our app that the user must accept before doing anythig. See issue #42 for more informations.

  In this PR I've created : 
  - The CGU structure/database with a version for each CGU
  - the API to get the current CGU version for the user. 
  - The business logic to validate the CGU
  What is Out of scope : 
  - The mix task to create a new CGU
  - The Admin API to manage the CGU

  This is only back-end related stuff. For the front-end part, see this issue : #1337 
-->

This PR modify the reusable workflow get-version so it will use convco to generate the version and now won't rely on the npm sementic-release.

## Technical highlight/advice
<!-- 
    This part is for technical stuff.
    - Tell us what did you change to implement the feature or fix the bug.
    - Don't detail it too much if it's simple stuff.
    - Add more information if you made significant changes that can affect others.

    For example : 
    To create the new API, I've created a new `CGUController` and a `CGU` Context.
    2 new routes : 
     - GET /api/cgu
     - POST /api/cgu/accept
    I've created a new table in the database with a migration.
    The CGU is linked to the user (Many to Many).
    I've added the rule to deny anyone that did not accept the CGU.
-->

## How to test my changes
<!-- 
  - How to start the project. Any other dependancies to update ? Any database migration ?
  - Step-by-step guide to reproduce the bug or test the new feature.

  Try to be rather explicit but keep it as simple as possible.

  Example : 
  - On server : 
    - `git checkout implement-cgu-validation`
    - `mix ecto.reset`
    - `mix ecto.migrate`
    - `mix phx.server`
  Use the thunder client in vscode : 
  - Register/Login (get the token)
  - Try to access this api without validating CGU : GET /api/apps. It should fail.
  - Validate the CGU ising the API POST /api/cgu/accept
  - Access the API agail, now it should work.
-->
You can test it using [act](https://nektosact.com/) : 
```sh
act --workflows ".github/workflows/get-version.yml"
```

Or by writing a new workflow in any repository : 
```yml
name: Mobile App CI/CD

on:
  push:

jobs:
  get-version:
    name: Get Version
    uses: lenra-io/github-actions/.github/workflows/get-version.yml@main
```

and running the act command on this repo : 
```sh
act --workflows ".github/workflows/build.yml" --local-repository "lenra-io/github-actions@main=~/github-actions"
```

In this command, I change the link from any workflow that try to get the reusable workflow to the local directory ~/github-actions so we can made change locally to test the action.

## Checklist
- [ ] I didn't over-scope my PR
- [ ] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I did not include breaking changes
- [ ] I made my own code-review before requesting one

### I included unit tests that cover my changes
- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### I added/updated the documentation about my changes
- [ ] 📜 README.md
- [ ] 📕 docs/*.md
- [ ] 📓 docs.lenra.io
- [ ] 🙅 no documentation needed


