### PR TITLE
feat: add check-run-status reusable workflow

### DIFF
--- a/.github/workflows/check-run-status.yml
+++ b/.github/workflows/check-run-status.yml
@@ -1,0 +1,127 @@
+name: Update PR Custom Status
+# description: Create or Update the status of a check run on a PR. This allow to create a custom message with a status on a PR.
+
+on:
+  workflow_call:
+    inputs:
+      check_run_id:
+        description: 'The ID of the check run to update (create one if not provided)'
+        required: false
+        type: number
+      name:
+        description: 'The name of the check. For example, "code-coverage".'
+        required: true
+        type: string
+      sha:
+        description: 'The commit SHA to update the status on (defaults to the triggering commit)'
+        required: false
+        type: string
+      status:
+        description: 'Pipeline status (e.g., queued, in_progress, completed )'
+        required: false
+        type: string
+        default: queued
+      conclusion:
+        description: 'The conclusion of the status (e.g., success, failure, neutral, cancelled, skipped, timed_out, action_required)'
+        required: false
+        type: string
+      output_title:
+        description: 'The title of the status (require output_summary)'
+        required: false
+        type: string
+      output_summary:
+        description: 'The summary of the status'
+        required: false
+        type: string
+      output_text:
+        description: 'The text of the status'
+        required: false
+        type: string
+      output_image_url:
+        description: 'The image URL of the status (require output_image_alt)'
+        required: false
+        type: string
+      output_image_alt:
+        description: 'The image alt text of the status'
+        required: false
+        type: string
+    outputs:
+      check-run-id:
+        description: 'The ID of the check run that was created or updated'
+        value: ${{ jobs.update-status.outputs.check-run-id }}
+
+permissions:
+  statuses: write
+
+jobs:
+  update-status:
+    runs-on: ubuntu-latest
+    outputs:
+      check-run-id: ${{ steps.check-run.outputs.result }}
+    steps:
+      - name: Set PR custom status
+        id: check-run
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Retrieve the input values
+            const check_run_id_input = '${{ inputs.check_run_id }}';
+            const name = '${{ inputs.name }}';
+            const status = '${{ inputs.status }}';
+            // Use the provided SHA or fall back to the current commit SHA
+            const sha = '${{ inputs.sha }}' || process.env.GITHUB_SHA;
+            const conclusion_input = '${{ inputs.conclusion }}';
+            const output_title = '${{ inputs.output_title }}';
+            const output_summary = '${{ inputs.output_summary }}';
+            const output_text = '${{ inputs.output_text }}';
+            const output_image_url = '${{ inputs.output_image_url }}';
+            const output_image_alt = '${{ inputs.output_image_alt }}';
+            
+            let check_run_id;
+            if(check_run_id_input) {
+              check_run_id = parseInt(check_run_id_input);
+            }
+
+            let output;
+            if (output_title) {
+              output = {
+                title: output_title,
+                summary: output_summary,
+                text: output_text
+              };
+              if(output_image_url) {
+                output.images = [{ alt: output_image_alt, image_url: output_image_url }];
+              }
+            }
+
+            let conclusion;
+            if (conclusion_input) {
+              conclusion = conclusion_input;
+            }
+
+            let url;
+            if(url_input) {
+              url = url_input;
+            }
+
+            // Extract owner and repo from the GITHUB_REPOSITORY environment variable
+            const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
+
+            // Create the Check Run
+            const octokit = github.getOctokit(process.env.GITHUB_TOKEN);
+            api_url = check_run_id ? 'POST /repos/{owner}/{repo}/check-runs' : 'PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}';
+            const checkRunResponse = await octokit.request(api_url, {
+              owner,
+              repo,
+              check_run_id,
+              name,
+              head_sha: sha,
+              status,
+              conclusion,
+              output,
+              headers: {
+                'X-GitHub-Api-Version': '2022-11-28'
+              }
+            });
+
+            return checkRunResponse.id;

--- a/docs/check-run-status.md
+++ b/docs/check-run-status.md
@@ -1,0 +1,46 @@
+# check-run-status.yml
+
+## How to use
+
+```yml
+  pre-coverage-feedback:
+    name: Prepare for Coverage Feedback
+    uses: lenra-io/github-actions/.github/workflows/check-run-status.yml@main
+    with:
+      name: 'Coverage Report'
+
+  test:
+    name: Test Flutter App
+    # Call the reusable workflow that runs test and generate a test coverage report into artifacts, artifact's name will be in outputs.
+    uses: lenra-io/github-actions/.github/workflows/test-flutter.yml@main
+
+  coverage:
+    name: Read Coverage Report
+    needs: test
+    uses: lenra-io/github-actions/.github/workflows/coverage-report.yml@main
+    with:
+      artifact-name: ${{ needs.test.outputs.artifact-name }}
+      artifact-path: lcov.info
+      min-lines-coverage: 20
+  
+  coverage_feedback:
+    name: Feedback on Coverage
+    needs: [pre-coverage-feedback, coverage]
+    uses: lenra-io/github-actions/.github/workflows/check-run-status.yml@main
+    if: ${{ needs.pre-coverage-feedback.result && always() }}
+    with:
+      check-run-id: ${{ needs.pre-coverage-feedback.outputs.check-run-id }}
+      name: 'Coverage Report'
+      status: completed
+      # Job success or failure
+      conclusion: ${{ needs.coverage.result }}
+      output_title: 'Coverage Report'
+      output_summary: 'Lines coverage at ${{ needs.coverage.outputs.lines-percentage }}% (${{ needs.coverage.outputs.lines-covered }}/${{ needs.coverage.outputs.lines-total }})'
+      output_text: |
+        lines......: ${{ needs.coverage.outputs.lines-percentage }}% (${{ needs.coverage.outputs.lines-covered }} of ${{ needs.coverage.outputs.lines-total }} lines)
+        functions..: ${{ needs.coverage.outputs.functions-percentage }}% (${{ needs.coverage.outputs.functions-covered }} of ${{ needs.coverage.outputs.functions-total }} functions)
+        branches...:  ${{ needs.coverage.outputs.branches-percentage }}% (${{ needs.coverage.outputs.branches-covered }} of ${{ needs.coverage.outputs.branches-total }} branches)
+```
+
+This example will create a new Run check status in the pull request, and after test got run, it will update it so it will tell the percentage of test coverage.
+This can use in many other way to inform the developer of steps of the run to be more clean.


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📜 Use Conventional Commit for your PR name (see https://www.conventionalcommits.org/en/v1.0.0/).
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->



## About this PR
<!-- 
Link the related issue if any.
-->
 
<!-- 
  - What is the bug/feature you make ? (If describe in the issue, don't repeat yourself, tell us)
  - Any other changes not in the issue ? Why did you add them ?
  - Add some scope to the changes if relevant
  - Try to give as much context as possible without any technical stuff here.

  For example : 
  We need some CGU in our app that the user must accept before doing anythig. See issue #42 for more informations.

  In this PR I've created : 
  - The CGU structure/database with a version for each CGU
  - the API to get the current CGU version for the user. 
  - The business logic to validate the CGU
  What is Out of scope : 
  - The mix task to create a new CGU
  - The Admin API to manage the CGU

  This is only back-end related stuff. For the front-end part, see this issue : #1337 
-->
This PR allow to create or update a status badge on the PR that run the workflow.
This will be useful to inform the developer of many changes he has to provide in his PR.
E.g. : Test coverage did not pass the minimum.

## Technical highlight/advice
<!-- 
    This part is for technical stuff.
    - Tell us what did you change to implement the feature or fix the bug.
    - Don't detail it too much if it's simple stuff.
    - Add more information if you made significant changes that can affect others.

    For example : 
    To create the new API, I've created a new `CGUController` and a `CGU` Context.
    2 new routes : 
     - GET /api/cgu
     - POST /api/cgu/accept
    I've created a new table in the database with a migration.
    The CGU is linked to the user (Many to Many).
    I've added the rule to deny anyone that did not accept the CGU.
-->

## How to test my changes
<!-- 
  - How to start the project. Any other dependancies to update ? Any database migration ?
  - Step-by-step guide to reproduce the bug or test the new feature.

  Try to be rather explicit but keep it as simple as possible.

  Example : 
  - On server : 
    - `git checkout implement-cgu-validation`
    - `mix ecto.reset`
    - `mix ecto.migrate`
    - `mix phx.server`
  Use the thunder client in vscode : 
  - Register/Login (get the token)
  - Try to access this api without validating CGU : GET /api/apps. It should fail.
  - Validate the CGU ising the API POST /api/cgu/accept
  - Access the API agail, now it should work.
-->


Best way to test this action is to start a new project with a single file (e.g. README.md) and to push it to a new github repository.

And to create a `.github/workflows/build.yml` workflows : 
```yml
name: Build

on:
  pull_request:

jobs:
  pre-coverage-feedback:
    name: Prepare for Coverage Feedback
    uses: lenra-io/github-actions/.github/workflows/check-run-status.yml@main
    with:
      name: 'Coverage Report'

  test:
    name: Test Flutter App
    # Mimic the test coverage report generation
    run: |
      echo "lines-percentage=82" >> $GITHUB_OUTPUTS
  
  coverage_feedback:
    name: Feedback on Coverage
    needs: [pre-coverage-feedback, test]
    uses: lenra-io/github-actions/.github/workflows/check-run-status.yml@main
    if: ${{ needs.pre-coverage-feedback.result && always() }}
    with:
      check-run-id: ${{ needs.pre-coverage-feedback.outputs.check-run-id }}
      name: 'Coverage Report'
      status: completed
      # Job success or failure
      conclusion: ${{ needs.test.result }}
      output_title: 'Coverage Report'
      output_summary: 'Lines coverage at ${{ needs.test.outputs.lines-percentage }}%'

```

And create a new Pull Request toward the main branch so that will run the CI.

!! Don't forget to replace the `@main` with the branch name you want to test on this github-action project.
## Checklist
- [ ] I didn't over-scope my PR
- [ ] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I did not include breaking changes
- [ ] I made my own code-review before requesting one

### I included unit tests that cover my changes
- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### I added/updated the documentation about my changes
- [ ] 📜 README.md
- [ ] 📕 docs/*.md
- [ ] 📓 docs.lenra.io
- [ ] 🙅 no documentation needed


