### PR TITLE
feat: add coverage-report reusable workflow

### DIFF
--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -1,0 +1,95 @@
+name: Coverage Report
+# description: Parse a coverage report and, if needed, check if the coverage is above a minimum threshold.
+
+on:
+  workflow_call:
+    inputs:
+      artifact-name:
+        type: string
+        description: Coverage report artifact name
+        required: true
+      artifact-path:
+        type: string
+        description: Path to the coverage report artifact
+        required: false
+        default: lcov.info
+      min-lines-coverage:
+        type: number
+        description: Minimum percentage of lines covered
+        required: false
+    outputs:
+      lines-covered:
+        description: 'Number of lines covered'
+        value: ${{ jobs.coverage.outputs.lines-covered }}
+      lines-total:
+        description: 'Total number of lines'
+        value: ${{ jobs.coverage.outputs.lines-total }}
+      lines-percentage:
+        description: 'Percentage of lines covered'
+        value: ${{ jobs.coverage.outputs.lines-percentage }}
+      functions-covered:
+        description: 'Number of functions covered'
+        value: ${{ jobs.coverage.outputs.functions-covered }}
+      functions-total:
+        description: 'Total number of functions'
+        value: ${{ jobs.coverage.outputs.functions-total }}
+      functions-percentage:
+        description: 'Percentage of functions covered'
+        value: ${{ jobs.coverage.outputs.functions-percentage }}
+      branches-covered:
+        description: 'Number of branches covered'
+        value: ${{ jobs.coverage.outputs.branches-covered }}
+      branches-total:
+        description: 'Total number of branches'
+        value: ${{ jobs.coverage.outputs.branches-total }}
+      branches-percentage:
+        description: 'Percentage of branches covered'
+        value: ${{ jobs.coverage.outputs.branches-percentage }}
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    outputs:
+      lines-covered: ${{ steps.coverage.outputs.lines-covered }}
+      lines-total: ${{ steps.coverage.outputs.lines-total }}
+      lines-percentage: ${{ steps.coverage.outputs.lines-percentage }}
+      functions-covered: ${{ steps.coverage.outputs.functions-covered }}
+      functions-total: ${{ steps.coverage.outputs.functions-total }}
+      functions-percentage: ${{ steps.coverage.outputs.functions-percentage }}
+      branches-covered: ${{ steps.coverage.outputs.branches-covered }}
+      branches-total: ${{ steps.coverage.outputs.branches-total }}
+      branches-percentage: ${{ steps.coverage.outputs.branches-percentage }}
+    steps:
+      - name: Download coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: coverage/
+      - name: Parse coverage report
+        id: coverage
+        run: |
+          regex='^\s+(\w+)\.+: ([0-9]+\.?[0-9]*)% \(([0-9]+) of ([0-9]+) \w+\)$'
+          while read -r line; do
+            if [[ $line =~ $regex ]]; then
+              if [[ "${BASH_REMATCH[1]}" == "lines" ]]; then
+                echo "lines-covered=${BASH_REMATCH[3]}" >> $GITHUB_OUTPUT
+                echo "lines-total=${BASH_REMATCH[4]}" >> $GITHUB_OUTPUT
+                echo "lines-percentage=${BASH_REMATCH[2]}" >> $GITHUB_OUTPUT
+              elif [[ "${BASH_REMATCH[1]}" == "functions" ]]; then
+                echo "functions-covered=${BASH_REMATCH[3]}" >> $GITHUB_OUTPUT
+                echo "functions-total=${BASH_REMATCH[4]}" >> $GITHUB_OUTPUT
+                echo "functions-percentage=${BASH_REMATCH[2]}" >> $GITHUB_OUTPUT
+              elif [[ "${BASH_REMATCH[1]}" == "branches" ]]; then
+                echo "branches-covered=${BASH_REMATCH[3]}" >> $GITHUB_OUTPUT
+                echo "branches-total=${BASH_REMATCH[4]}" >> $GITHUB_OUTPUT
+                echo "branches-percentage=${BASH_REMATCH[2]}" >> $GITHUB_OUTPUT
+              fi
+            fi
+          done < <(lcov --summary ${{ inputs.artifact-path }})
+      - name: Check coverage report data
+        if: ${{ inputs.min-lines-coverage }}
+        run: |
+          if [[ ${{ steps.coverage.outputs.lines-percentage }} -lt ${{ inputs.min-lines-coverage }} ]]; then
+            echo "Coverage is below the minimum required (${{ inputs.min-lines-coverage }}%): ${{ steps.coverage.outputs.lines-percentage }}%"
+            exit 1
+          fi

--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -71,11 +71,9 @@ jobs:
           regex='^\s*(lines|functions|branches)\.+: ([0-9]+\.?[0-9]*)% \(([0-9]+) of ((?:[0-9]+,?)+) \w+\)$'
           while read -r line; do
             if [[ $line =~ $regex ]]; then
-              if [ -n "${BASH_REMATCH[1]}" ]; then
-                echo "${BASH_REMATCH[1]}-covered=${BASH_REMATCH[3]}" >> $GITHUB_OUTPUT
-                echo "${BASH_REMATCH[1]}-total=${BASH_REMATCH[4]}" >> $GITHUB_OUTPUT
-                echo "${BASH_REMATCH[1]}-percentage=${BASH_REMATCH[2]}" >> $GITHUB_OUTPUT
-              fi
+              echo "${BASH_REMATCH[1]}-covered=${BASH_REMATCH[3]}" >> $GITHUB_OUTPUT
+              echo "${BASH_REMATCH[1]}-total=${BASH_REMATCH[4]}" >> $GITHUB_OUTPUT
+              echo "${BASH_REMATCH[1]}-percentage=${BASH_REMATCH[2]}" >> $GITHUB_OUTPUT
             fi
           done < <(lcov --summary ${{ inputs.artifact-path }})
       - name: Check coverage report data

--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Parse coverage report
         id: coverage
         run: |
-          regex='^\s*(lines|functions|branches)\.+: ([0-9]+\.?[0-9]*)% \(([0-9]+) of ((?:[0-9]+,?)+) \w+\)$'
+          regex='^\s*(lines|functions|branches)\.+: ([0-9]+\.?[0-9]*)% \(([0-9]+) of ([0-9]+) \w+\)$'
           while read -r line; do
             if [[ $line =~ $regex ]]; then
               echo "${BASH_REMATCH[1]}-covered=${BASH_REMATCH[3]}" >> $GITHUB_OUTPUT

--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -68,21 +68,13 @@ jobs:
       - name: Parse coverage report
         id: coverage
         run: |
-          regex='^\s+(\w+)\.+: ([0-9]+\.?[0-9]*)% \(([0-9]+) of ([0-9]+) \w+\)$'
+          regex='^\s*(lines|functions|branches)\.+: ([0-9]+\.?[0-9]*)% \(([0-9]+) of ((?:[0-9]+,?)+) \w+\)$'
           while read -r line; do
             if [[ $line =~ $regex ]]; then
-              if [[ "${BASH_REMATCH[1]}" == "lines" ]]; then
-                echo "lines-covered=${BASH_REMATCH[3]}" >> $GITHUB_OUTPUT
-                echo "lines-total=${BASH_REMATCH[4]}" >> $GITHUB_OUTPUT
-                echo "lines-percentage=${BASH_REMATCH[2]}" >> $GITHUB_OUTPUT
-              elif [[ "${BASH_REMATCH[1]}" == "functions" ]]; then
-                echo "functions-covered=${BASH_REMATCH[3]}" >> $GITHUB_OUTPUT
-                echo "functions-total=${BASH_REMATCH[4]}" >> $GITHUB_OUTPUT
-                echo "functions-percentage=${BASH_REMATCH[2]}" >> $GITHUB_OUTPUT
-              elif [[ "${BASH_REMATCH[1]}" == "branches" ]]; then
-                echo "branches-covered=${BASH_REMATCH[3]}" >> $GITHUB_OUTPUT
-                echo "branches-total=${BASH_REMATCH[4]}" >> $GITHUB_OUTPUT
-                echo "branches-percentage=${BASH_REMATCH[2]}" >> $GITHUB_OUTPUT
+              if [ -n "${BASH_REMATCH[1]}" ]; then
+                echo "${BASH_REMATCH[1]}-covered=${BASH_REMATCH[3]}" >> $GITHUB_OUTPUT
+                echo "${BASH_REMATCH[1]}-total=${BASH_REMATCH[4]}" >> $GITHUB_OUTPUT
+                echo "${BASH_REMATCH[1]}-percentage=${BASH_REMATCH[2]}" >> $GITHUB_OUTPUT
               fi
             fi
           done < <(lcov --summary ${{ inputs.artifact-path }})

--- a/docs/coverage-report.md
+++ b/docs/coverage-report.md
@@ -1,0 +1,23 @@
+# coverage-report.yml
+
+## Example of usage
+
+```yml
+name: Build
+
+on:
+  push:
+
+jobs:
+  test:
+    name: Test Flutter App
+    uses: lenra-io/github-actions/.github/workflows/test-flutter.yml@main
+  coverage:
+    name: Read Coverage Report
+    needs: test
+    uses: lenra-io/github-actions/.github/workflows/coverage-report.yml@main
+    with:
+      artifact-name: ${{ needs.test.outputs.artifact-name }}
+      artifact-path: lcov.info
+      min-lines-coverage: 20
+```


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📜 Use Conventional Commit for your PR name (see https://www.conventionalcommits.org/en/v1.0.0/).
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->



## About this PR
<!-- 
Link the related issue if any.
-->

<!-- 
  - What is the bug/feature you make ? (If describe in the issue, don't repeat yourself, tell us)
  - Any other changes not in the issue ? Why did you add them ?
  - Add some scope to the changes if relevant
  - Try to give as much context as possible without any technical stuff here.

  For example : 
  We need some CGU in our app that the user must accept before doing anythig. See issue #42 for more informations.

  In this PR I've created : 
  - The CGU structure/database with a version for each CGU
  - the API to get the current CGU version for the user. 
  - The business logic to validate the CGU
  What is Out of scope : 
  - The mix task to create a new CGU
  - The Admin API to manage the CGU

  This is only back-end related stuff. For the front-end part, see this issue : #1337 
-->
This PR add a workflow that can parse lcov file and output to github workflow syntax the summary of this report.

## Technical highlight/advice
<!-- 
    This part is for technical stuff.
    - Tell us what did you change to implement the feature or fix the bug.
    - Don't detail it too much if it's simple stuff.
    - Add more information if you made significant changes that can affect others.

    For example : 
    To create the new API, I've created a new `CGUController` and a `CGU` Context.
    2 new routes : 
     - GET /api/cgu
     - POST /api/cgu/accept
    I've created a new table in the database with a migration.
    The CGU is linked to the user (Many to Many).
    I've added the rule to deny anyone that did not accept the CGU.
-->

## How to test my changes
<!-- 
  - How to start the project. Any other dependancies to update ? Any database migration ?
  - Step-by-step guide to reproduce the bug or test the new feature.

  Try to be rather explicit but keep it as simple as possible.

  Example : 
  - On server : 
    - `git checkout implement-cgu-validation`
    - `mix ecto.reset`
    - `mix ecto.migrate`
    - `mix phx.server`
  Use the thunder client in vscode : 
  - Register/Login (get the token)
  - Try to access this api without validating CGU : GET /api/apps. It should fail.
  - Validate the CGU ising the API POST /api/cgu/accept
  - Access the API agail, now it should work.
-->

Simpliest way to test this change is to create a new flutter project : 
```sh
flutter create mobile
```

And to write a new `.github/workflows/build.yml` file that will use the `test-flutter` workflow I made : 
```yml
name: Build

on:
  push:

jobs:
  test:
    name: Test Flutter App
    uses: lenra-io/github-actions/.github/workflows/test-flutter.yml@main
  coverage:
    name: Read Coverage Report
    needs: test
    uses: lenra-io/github-actions/.github/workflows/coverage-report.yml@main
    with:
      artifact-name: ${{ needs.test.outputs.artifact-name }}
      artifact-path: lcov.info
      min-lines-coverage: 20
```

Then you can run the workflow using this [act](https://nektosact.com/) command : 
```sh
act --workflows ".github/workflows/build.yml" --job "coverage" --local-repository "lenra-io/github-actions@main=~/github-actions"
```


## Checklist
- [ ] I didn't over-scope my PR
- [ ] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I did not include breaking changes
- [ ] I made my own code-review before requesting one

### I included unit tests that cover my changes
- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### I added/updated the documentation about my changes
- [ ] 📜 README.md
- [ ] 📕 docs/*.md
- [ ] 📓 docs.lenra.io
- [ ] 🙅 no documentation needed


