### PR TITLE
fix(test-springboot): wait for compose services to be healthy before testing

### DIFF
--- a/.github/workflows/test-springboot.yml
+++ b/.github/workflows/test-springboot.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Run compose-file
         if: inputs.compose-file != ''
         run: |
-          docker compose -f ${{ inputs.compose-file }}  --profile ${{ inputs.compose-profile }} up -d
+          docker compose -f ${{ inputs.compose-file }}  --profile ${{ inputs.compose-profile }} up -d --wait
           
       - name: Build with Gradle
         run: gradle ${{ inputs.gradle-job }}


### PR DESCRIPTION
## Summary
- `docker compose up -d` returns as soon as containers start, not once they're actually ready to accept connections.
- For consumers of `compose-file`/`compose-profile` inputs with a healthcheck defined (e.g. Postgres via `pg_isready`), this let the test step run before the service was actually ready, causing persistent connection-refused failures in downstream test suites.
- Add `--wait` to the `docker compose up -d` invocation so the step blocks until all started services report healthy.

## Context
Found while investigating a persistently failing "Test Spring Boot App" check on [lenra-io/Ximiti#47](https://github.com/lenra-io/Ximiti/pull/47): a new test suite connecting directly to Postgres kept failing with `ConnectException` for the entire retry window, even after retries up to 180s, while the Postgres container had already reported "Started". Postgres's `pg_isready` healthcheck in `compose.yml` was already defined but never actually waited on.

## Test plan
- [ ] Re-run the "Test Spring Boot App" check on lenra-io/Ximiti#47 once this merges to `main` (it references `@main`) and confirm it passes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TL6pCfntXtngvHJj64YjvG)_