### PR TITLE
fix(check-flutter,test-flutter): run flutter pub get before analyze/test

### DIFF
--- a/.github/workflows/_check_pr.yml
+++ b/.github/workflows/_check_pr.yml
@@ -19,11 +19,10 @@ jobs:
           IGNORED_FILES: "${{ vars.ci_ignored_files }}"
         run: |
           branch=$(echo "${{ github.ref_name }}" | sed -e 's/refs\/heads\///g')
-          ignore_rules=''
-          if [ -n "$IGNORED_FILES" ]; then
-            ignore_rules=' | grep -vE "($IGNORED_FILES)"'
+          files=$(grep -lE "uses: lenra-io/github-actions/*@${branch}" .github/workflows/* || true)
+          if [ -n "$IGNORED_FILES" ] && [ -n "$files" ]; then
+            files=$(echo "$files" | grep -vE "($IGNORED_FILES)" || true)
           fi
-          files=$(grep -lE "uses: lenra-io/github-actions/*@${branch}" .github/workflows/* ${ignore_rules}")
           if [ -n "$files" ]; then
             echo "The following files contains an action that uses the @${branch} version instead of @main:"
             echo "$files"

--- a/.github/workflows/check-flutter.yml
+++ b/.github/workflows/check-flutter.yml
@@ -38,6 +38,9 @@ jobs:
           cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'
           cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:"
 
+      - name: Install dependencies
+        run: flutter pub get
+
       - name: Run checks
         id: Check
         run: flutter analyze

--- a/.github/workflows/test-flutter.yml
+++ b/.github/workflows/test-flutter.yml
@@ -57,6 +57,9 @@ jobs:
           cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'
           cache-path: "${{ runner.tool_cache }}/flutter/:channel:-:version:-:arch:"
 
+      - name: Install dependencies
+        run: flutter pub get
+
       - name: Run tests and generate coverage report
         id: test
         run: |


### PR DESCRIPTION
## Summary

`check-flutter.yml` and `test-flutter.yml` run `flutter analyze`/`flutter test` directly, relying on their implicit dependency resolution. That resolution does not trigger a consuming app's `generate: true` l10n codegen (`flutter gen-l10n`, via `pubspec.yaml`) the way an explicit `flutter pub get` does — confirmed locally (same Flutter version, explicit `pub get` regenerates `lib/generated/l10n/*.dart`, `flutter analyze`'s own resolution does not).

`build-flutter.yml` already runs `flutter pub get` explicitly before `flutter build` — this brings `check-flutter.yml`/`test-flutter.yml` in line with that.

Consuming apps that commit their generated l10n sources happen to work around this; apps that gitignore them (the standard Flutter convention) get spurious "Target of URI doesn't exist" / "Undefined name 'AppLocalizations'" failures in `check`/`test` even though the code is correct.

Found while working on [lenra-io/Ximiti#167](https://github.com/lenra-io/Ximiti/pull/167).

## Test plan

- [ ] Verify `lenra-io/Ximiti#167`'s CI goes green once this workflow change is referenced (it currently pins `@main`, so merging this should flow through automatically).


---
_Generated by [Claude Code](https://claude.ai/code/session_01NMMg4V3FiMmPZjKkYVhZpg)_